### PR TITLE
Replace deprecated calls

### DIFF
--- a/Swiftify/ContentView.swift
+++ b/Swiftify/ContentView.swift
@@ -8,13 +8,13 @@ struct ContentView: View {
   var body: some View {
     NavigationView {
       VStack {
-        TextField($pattern, placeholder: Text("Type a regex"))
+        TextField("Type a regex", text: $pattern)
           .textFieldStyle(.roundedBorder)
 
         HighlightedText(text, highlighting: regex) { match in
           match
             .bold()
-            .color(.red)
+            .foregroundColor(.red)
         }
         .lineLimit(nil)
         .foregroundColor(.secondary)


### PR DESCRIPTION
- TextField simplified the init of placeholder text

> 'init(_:placeholder:onEditingChanged:onCommit:)' is deprecated

- Color has been replaced with foregroundColor

> 'color' is deprecated: renamed to 'foregroundColor'
> Use 'foregroundColor' instead